### PR TITLE
Add boxed errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
+use crate::std::boxed::Box;
 use crate::std::string::String;
+use ark_std::error::Error;
 
 /// Common errors for the `AccumulationScheme` trait.
 #[derive(Debug)]
-pub enum Error {
+pub enum ASError {
     /// The accumulator was corrupted or malformed.
     MalformedAccumulator(String),
 
@@ -16,17 +18,38 @@ pub enum Error {
     MissingRng(String),
 }
 
-impl core::fmt::Display for Error {
+impl core::fmt::Display for ASError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let error_text = match self {
-            Error::MalformedAccumulator(err) => format!("MalformedAccumulator: {}", err),
-            Error::MalformedInput(err) => format!("MalformedInput: {}", err),
-            Error::MissingAccumulatorsAndInputs(err) => format!("NothingToAccumulate: {}", err),
-            Error::MissingRng(err) => format!("MissingRng: {}", err),
+            ASError::MalformedAccumulator(err) => format!("MalformedAccumulator: {}", err),
+            ASError::MalformedInput(err) => format!("MalformedInput: {}", err),
+            ASError::MissingAccumulatorsAndInputs(err) => {
+                format!("MissingAccumulatorsAndInputs: {}", err)
+            }
+            ASError::MissingRng(err) => format!("MissingRng: {}", err),
         };
 
         write!(f, "{}", error_text)
     }
 }
 
-impl ark_std::error::Error for Error {}
+impl Error for ASError {}
+
+/// Wrapper struct holding any ark_std error
+#[derive(Debug)]
+pub struct BoxedError(pub Box<dyn Error>);
+
+impl BoxedError {
+    /// Converts from a static error into the boxed form
+    pub fn new(err: impl Error + 'static) -> Self {
+        Self(Box::new(err))
+    }
+}
+
+impl core::fmt::Display for BoxedError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self.0.as_ref(), f)
+    }
+}
+
+impl Error for BoxedError {}


### PR DESCRIPTION
Boxed errors are useful for accumulation schemes where there are a lot of different types of errors (eg. ASError, PCError, LHError for linear hashes).