### PR TITLE
Add placeholder functions and absorbable impl to R1CS_NARK_AS VK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ derivative = { version = "2.1.1", default-features = false, features = [ "use_co
 
 # Dependencies for r1cs
 ark-crypto-primitives = { version = "^0.2.0", default-features = false, optional = true }
-ark-nonnative-field = { version = "^0.2.0", default-features = false, optional = true }
+ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false, optional = true }
 ark-relations = { version = "^0.2.0", default-features = false, optional = true }
 ark-r1cs-std = { version = "^0.2.0", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }

--- a/src/hp_as/constraints/data_structures.rs
+++ b/src/hp_as/constraints/data_structures.rs
@@ -42,6 +42,12 @@ impl<CF: PrimeField> AllocVar<usize, CF> for VerifierKeyVar<CF> {
     }
 }
 
+impl<CF: PrimeField> AbsorbableGadget<CF> for VerifierKeyVar<CF> {
+    fn to_sponge_field_elements(&self) -> Result<Vec<FpVar<CF>>, SynthesisError> {
+        collect_sponge_field_elements_gadget!(self.num_supported_elems)
+    }
+}
+
 /// The [`InputInstance`][input] of the [`ASForHPVerifierGadget`][as_for_hp_verifier].
 ///
 /// [input]: crate::constraints::ASVerifierGadget::InputInstance

--- a/src/r1cs_nark_as/constraints/data_structures.rs
+++ b/src/r1cs_nark_as/constraints/data_structures.rs
@@ -83,7 +83,7 @@ impl<CF: PrimeField> AllocVar<VerifierKey, CF> for VerifierKeyVar<CF> {
 
 impl<CF: PrimeField> AbsorbableGadget<CF> for VerifierKeyVar<CF> {
     fn to_sponge_field_elements(&self) -> Result<Vec<FpVar<CF>>, SynthesisError> {
-        let num_instance_variables = FpVar::Constant(CF::from(self.num_instance_variables as u128));
+        let num_instance_variables = FpVar::Constant(CF::from(self.num_instance_variables as u64));
         collect_sponge_field_elements_gadget!(
             num_instance_variables,
             self.hp_as_vk,

--- a/src/r1cs_nark_as/constraints/mod.rs
+++ b/src/r1cs_nark_as/constraints/mod.rs
@@ -1,8 +1,6 @@
 use crate::constraints::ASVerifierGadget;
 use crate::hp_as::constraints::ASForHPVerifierGadget;
-use crate::hp_as::constraints::{
-    InputInstanceVar as HPInputInstanceVar, VerifierKeyVar as HPVerifierKeyVar,
-};
+use crate::hp_as::constraints::InputInstanceVar as HPInputInstanceVar;
 use crate::r1cs_nark_as::{
     r1cs_nark, ASForR1CSNark, InputInstance, CHALLENGE_SIZE, HP_AS_PROTOCOL_NAME, PROTOCOL_NAME,
 };
@@ -169,9 +167,12 @@ where
     }
 
     /// Blinds the commitments from the first round messages.
-    #[tracing::instrument(target = "r1cs", skip(index_info, input_instances, nark_sponge))]
+    #[tracing::instrument(
+        target = "r1cs",
+        skip(nark_matrices_hash, input_instances, nark_sponge)
+    )]
     fn compute_blinded_commitments(
-        index_info: &IndexInfoVar<ConstraintF<G>>,
+        nark_matrices_hash: &Vec<FpVar<ConstraintF<G>>>,
         input_instances: &Vec<&InputInstanceVar<G, C>>,
         mut nark_sponge: impl CryptographicSpongeVar<ConstraintF<G>, S>,
     ) -> Result<(Vec<C>, Vec<C>, Vec<C>, Vec<C>), SynthesisError> {
@@ -180,7 +181,7 @@ where
         let mut all_blinded_comm_c = Vec::with_capacity(input_instances.len());
         let mut all_blinded_comm_prod = Vec::with_capacity(input_instances.len());
 
-        nark_sponge.absorb(&index_info.matrices_hash)?;
+        nark_sponge.absorb(nark_matrices_hash)?;
 
         for instance in input_instances {
             let first_round_message: &FirstRoundMessageVar<G, C> = &instance.first_round_message;
@@ -438,7 +439,7 @@ where
         let hp_sponge = sponge.fork(HP_AS_PROTOCOL_NAME)?;
 
         let make_zk_enabled = proof.randomness.is_some();
-        let r1cs_input_len = verifier_key.nark_index.num_instance_variables;
+        let r1cs_input_len = verifier_key.num_instance_variables;
 
         let mut input_instances = input_instances.into_iter().collect::<Vec<_>>();
         for instance in &input_instances {
@@ -481,7 +482,7 @@ where
         // Step 2 of the scheme's accumulation verifier, as detailed in BCLMS20.
         let (all_blinded_comm_a, all_blinded_comm_b, all_blinded_comm_c, all_blinded_comm_prod) =
             Self::compute_blinded_commitments(
-                &verifier_key.nark_index,
+                &verifier_key.nark_matrices_hash,
                 &input_instances,
                 nark_sponge,
             )?;
@@ -497,15 +498,9 @@ where
             .iter()
             .map(|instance| &instance.hp_instance);
 
-        // Step 4 of the scheme's accumulation verifier, as detailed in BCLMS20.
-        let hp_vk = HPVerifierKeyVar::<ConstraintF<G>>::new_constant(
-            cs.clone(),
-            verifier_key.nark_index.num_constraints,
-        )?;
-
         let hp_verify = ASForHPVerifierGadget::<G, C, S, SV>::verify(
             cs,
-            &hp_vk,
+            &verifier_key.hp_as_vk,
             &hp_input_instances,
             hp_accumulator_instances,
             &new_accumulator_instance.hp_instance,

--- a/src/r1cs_nark_as/mod.rs
+++ b/src/r1cs_nark_as/mod.rs
@@ -7,7 +7,7 @@ use crate::hp_as::{
     InputWitnessRandomness as HPInputWitnessRandomness,
 };
 use crate::r1cs_nark_as::r1cs_nark::{
-    hash_matrices, matrix_vec_mul, FirstRoundMessage, IndexInfo, IndexVerifierKey,
+    hash_matrices, matrix_vec_mul, FirstRoundMessage, IndexVerifierKey,
     PublicParameters as NARKPublicParameters, R1CSNark, SecondRoundMessage,
 };
 use crate::ConstraintF;
@@ -204,7 +204,7 @@ where
 
     /// Blinds the commitments from the first round messages.
     fn compute_blinded_commitments(
-        index_info: &IndexInfo,
+        nark_matrices_hash: &[u8; 32],
         input_instances: &Vec<&InputInstance<G>>,
         nark_sponge: S,
     ) -> (Vec<G>, Vec<G>, Vec<G>, Vec<G>) {
@@ -223,7 +223,7 @@ where
 
             if let Some(first_msg_randomness) = instance.first_round_message.randomness.as_ref() {
                 let gamma_challenge = R1CSNark::<G, S>::compute_challenge(
-                    index_info,
+                    nark_matrices_hash,
                     instance.r1cs_input.as_slice(),
                     first_round_message,
                     nark_sponge.clone(),
@@ -694,7 +694,9 @@ where
         };
 
         let vk = VerifierKey {
-            nark_index: ivk.index_info.clone(),
+            num_instance_variables: ivk.index_info.num_instance_variables,
+            num_constraints: ivk.index_info.num_constraints,
+            nark_matrices_hash: ivk.index_info.matrices_hash.clone(),
             as_matrices_hash,
         };
 
@@ -806,7 +808,7 @@ where
         // Step 2 of the scheme's accumulation prover, as detailed in BCLMS20.
         let (all_blinded_comm_a, all_blinded_comm_b, all_blinded_comm_c, all_blinded_comm_prod) =
             Self::compute_blinded_commitments(
-                &prover_key.nark_pk.index_info,
+                &prover_key.nark_pk.index_info.matrices_hash,
                 &input_instances,
                 nark_sponge,
             );
@@ -938,7 +940,7 @@ where
         let hp_sponge = sponge.fork(HP_AS_PROTOCOL_NAME);
 
         let make_zk_enabled = proof.randomness.is_some();
-        let r1cs_input_len = verifier_key.nark_index.num_instance_variables;
+        let r1cs_input_len = verifier_key.num_instance_variables;
 
         let mut input_instances = input_instances.into_iter().collect::<Vec<_>>();
         for instance in &input_instances {
@@ -978,7 +980,7 @@ where
         // Step 2 of the scheme's accumulation verifier, as detailed in BCLMS20.
         let (all_blinded_comm_a, all_blinded_comm_b, all_blinded_comm_c, all_blinded_comm_prod) =
             Self::compute_blinded_commitments(
-                &verifier_key.nark_index,
+                &verifier_key.nark_matrices_hash,
                 &input_instances,
                 nark_sponge,
             );
@@ -996,7 +998,7 @@ where
 
         // Step 4 of the scheme's accumulation verifier, as detailed in BCLMS20.
         let hp_verify = ASForHadamardProducts::<G, S>::verify(
-            &verifier_key.nark_index.num_constraints,
+            &verifier_key.num_constraints,
             &hp_input_instances,
             hp_accumulator_instances,
             &new_accumulator_instance.hp_instance,

--- a/src/r1cs_nark_as/r1cs_nark/mod.rs
+++ b/src/r1cs_nark_as/r1cs_nark/mod.rs
@@ -47,12 +47,12 @@ where
     S: CryptographicSponge<ConstraintF<G>>,
 {
     pub(crate) fn compute_challenge(
-        index_info: &IndexInfo,
+        matrices_hash: &[u8; 32],
         input: &[G::ScalarField],
         msg: &FirstRoundMessage<G>,
         mut sponge: S,
     ) -> G::ScalarField {
-        sponge.absorb(&index_info.matrices_hash.as_ref());
+        sponge.absorb(&matrices_hash.as_ref());
 
         let input_bytes = input
             .iter()
@@ -282,7 +282,7 @@ where
 
         // Step 7 of the scheme's prover, as detailed in BCLMS20.
         let gamma = Self::compute_challenge(
-            &ipk.index_info,
+            &ipk.index_info.matrices_hash,
             &input,
             &first_msg,
             sponge.unwrap_or_else(|| S::new()),
@@ -352,7 +352,7 @@ where
 
         // Step 2 of the scheme's verifier, as detailed in BCLMS20.
         let gamma = Self::compute_challenge(
-            &ivk.index_info,
+            &ivk.index_info.matrices_hash,
             &input,
             &proof.first_msg,
             sponge.unwrap_or_else(|| S::new()),
@@ -470,7 +470,7 @@ fn inner_prod<F: Field>(row: &[(F, usize)], input: &[F], witness: &[F]) -> F {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use ark_ff::UniformRand;
+    use ark_ff::{PrimeField, UniformRand};
     use ark_pallas::{Affine, Fq, Fr};
     use ark_relations::{
         lc,


### PR DESCRIPTION
Implements a placeholder function for the `ASForR1CSNark` verifier key. This placeholder function is intended to allow a verifier key variable to be initialized in a constraint system when the number of public inputs is known.

Additionally, simplifies the contents of the verifier key to remove unnecessary elements, namely `num_variables` from the IndexInfo. This simplification enables the new `Absorbable` implementations to only absorb the necessary elements relevant to the verifier key functionality.