### PR TITLE
Removes the input witness struct of ASForR1CSNark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ derivative = { version = "2.1.1", default-features = false, features = [ "use_co
 
 # Dependencies for r1cs
 ark-crypto-primitives = { version = "^0.2.0", default-features = false, optional = true }
-ark-nonnative-field = { version = "^0.2.0", default-features = false, optional = true }
+ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false, optional = true }
 ark-relations = { version = "^0.2.0", default-features = false, optional = true }
 ark-r1cs-std = { version = "^0.2.0", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }

--- a/src/r1cs_nark_as/data_structures.rs
+++ b/src/r1cs_nark_as/data_structures.rs
@@ -105,19 +105,7 @@ where
 ///
 /// [input_witness]: crate::AccumulationScheme::InputWitness
 /// [as_for_r1cs_nark]: crate::r1cs_nark_as::ASForR1CSNark
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
-pub struct InputWitness<F: Field> {
-    /// The sigma protocol's prover commitment of the NARK.
-    pub second_round_message: SecondRoundMessage<F>,
-}
-
-impl<F: Field> InputWitness<F> {
-    pub(crate) fn zero(witness_len: usize) -> Self {
-        Self {
-            second_round_message: SecondRoundMessage::zero(witness_len),
-        }
-    }
-}
+pub type InputWitness<F> = SecondRoundMessage<F>;
 
 /// The [`AccumulatorInstance`][acc_instance] of the [`ASForR1CSNark`][as_for_r1cs_nark].
 ///

--- a/src/r1cs_nark_as/mod.rs
+++ b/src/r1cs_nark_as/mod.rs
@@ -54,7 +54,7 @@ pub(self) const CHALLENGE_SIZE: usize = 128;
 /// # Example Input
 /// ```
 ///
-/// use ark_accumulation::r1cs_nark_as::{ASForR1CSNark, InputInstance, InputWitness};
+/// use ark_accumulation::r1cs_nark_as::{ASForR1CSNark, InputInstance};
 /// use ark_accumulation::r1cs_nark_as::r1cs_nark::{FirstRoundMessage, SecondRoundMessage};
 /// use ark_accumulation::Input;
 /// use ark_ec::AffineCurve;
@@ -84,9 +84,7 @@ pub(self) const CHALLENGE_SIZE: usize = 128;
 ///         first_round_message: first_msg,
 ///     };
 ///
-///     let witness = InputWitness {
-///         second_round_message: second_msg,
-///     };
+///     let witness = second_msg;
 ///
 ///     Input::<_, _, ASForR1CSNark<G, CS, S>> { instance, witness }
 /// }
@@ -134,7 +132,7 @@ where
     ) -> Result<(), BoxedError> {
         // The length of the R1CS witness must be equal to those of the other R1CS witnesses being
         // accumulated.
-        if input_witness.second_round_message.blinded_witness.len() != r1cs_witness_len {
+        if input_witness.blinded_witness.len() != r1cs_witness_len {
             return Err(BoxedError::new(MalformedInput(
                 "All R1CS witness lengths must be equal and supported by the index prover key."
                     .to_string(),
@@ -156,7 +154,7 @@ where
         // The randomness requirements of the first round message and the second round messages
         // must match.
         if input.instance.first_round_message.randomness.is_some()
-            != input.witness.second_round_message.randomness.is_some()
+            != input.witness.randomness.is_some()
         {
             return Err(BoxedError::new(MalformedInput(
                 "The existence of the first round message randomness and the second round \
@@ -310,8 +308,7 @@ where
             .into_iter()
             .zip(input_witnesses)
             .map(|(instance, witness)| {
-                let second_round_message: &SecondRoundMessage<G::ScalarField> =
-                    &witness.second_round_message;
+                let second_round_message: &SecondRoundMessage<G::ScalarField> = witness;
 
                 let a_vec = matrix_vec_mul(
                     &prover_key.nark_pk.a,
@@ -560,41 +557,35 @@ where
             .chain(
                 input_witnesses
                     .iter()
-                    .map(|witness| &witness.second_round_message.blinded_witness),
+                    .map(|witness| &witness.blinded_witness),
             );
 
         let all_sigma_a = accumulator_witnesses
             .iter()
             .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_a))
-            .chain(input_witnesses.iter().map(|witness| {
-                witness
-                    .second_round_message
-                    .randomness
-                    .as_ref()
-                    .map(|r| &r.sigma_a)
-            }));
+            .chain(
+                input_witnesses
+                    .iter()
+                    .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_a)),
+            );
 
         let all_sigma_b = accumulator_witnesses
             .iter()
             .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_b))
-            .chain(input_witnesses.iter().map(|witness| {
-                witness
-                    .second_round_message
-                    .randomness
-                    .as_ref()
-                    .map(|r| &r.sigma_b)
-            }));
+            .chain(
+                input_witnesses
+                    .iter()
+                    .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_b)),
+            );
 
         let all_sigma_c = accumulator_witnesses
             .iter()
             .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_c))
-            .chain(input_witnesses.iter().map(|witness| {
-                witness
-                    .second_round_message
-                    .randomness
-                    .as_ref()
-                    .map(|r| &r.sigma_c)
-            }));
+            .chain(
+                input_witnesses
+                    .iter()
+                    .map(|witness| witness.randomness.as_ref().map(|r| &r.sigma_c)),
+            );
 
         let (r1cs_blinded_witnesses, all_sigma_a, all_sigma_b, all_sigma_c) =
             if let Some((r1cs_r_witness, rand_1, rand_2, rand_3)) = prover_witness_randomness {
@@ -764,7 +755,7 @@ where
         // Ensure that none of the inputs or accumulators require zero-knowledge.
         if !make_zk_enabled {
             for witness in &input_witnesses {
-                if witness.second_round_message.randomness.is_some() {
+                if witness.randomness.is_some() {
                     return Err(BoxedError::new(ASError::MissingRng(
                         "Accumulating inputs with hiding requires rng.".to_string(),
                     )));
@@ -1110,7 +1101,7 @@ where
 pub mod tests {
     use crate::data_structures::Input;
     use crate::error::BoxedError;
-    use crate::r1cs_nark_as::data_structures::{InputInstance, InputWitness};
+    use crate::r1cs_nark_as::data_structures::InputInstance;
     use crate::r1cs_nark_as::r1cs_nark::IndexProverKey;
     use crate::r1cs_nark_as::r1cs_nark::R1CSNark;
     use crate::r1cs_nark_as::{r1cs_nark, ASForR1CSNark};
@@ -1263,9 +1254,7 @@ pub mod tests {
                     first_round_message: proof.first_msg.clone(),
                 };
 
-                let witness = InputWitness {
-                    second_round_message: proof.second_msg,
-                };
+                let witness = proof.second_msg;
 
                 inputs.push(
                     Input::<_, _, ASForR1CSNark<G, DummyCircuit<G::ScalarField>, S>> {


### PR DESCRIPTION
The input witness of ASForR1CSNark is the SecondRoundMessage of R1CSNark. There is no need for a wrapper around it, so the commit removes the struct and uses SecondRoundMessage directly.